### PR TITLE
Don't error on autoservice missing from classpath

### DIFF
--- a/processor/src/main/kotlin/dev/zacsweers/autoservice/ksp/AutoServiceSymbolProcessor.kt
+++ b/processor/src/main/kotlin/dev/zacsweers/autoservice/ksp/AutoServiceSymbolProcessor.kt
@@ -35,14 +35,7 @@ import com.squareup.kotlinpoet.ClassName
 import java.io.IOException
 import java.util.SortedSet
 
-@AutoService(SymbolProcessorProvider::class)
-public class AutoServiceSymbolProcessorProvider : SymbolProcessorProvider {
-  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
-      AutoServiceSymbolProcessor(environment)
-}
-
-private class AutoServiceSymbolProcessor(environment: SymbolProcessorEnvironment) :
-    SymbolProcessor {
+public class AutoServiceSymbolProcessor(environment: SymbolProcessorEnvironment) : SymbolProcessor {
 
   private companion object {
     const val AUTO_SERVICE_NAME = "com.google.auto.service.AutoService"
@@ -198,5 +191,11 @@ private class AutoServiceSymbolProcessor(environment: SymbolProcessorEnvironment
 
     val simpleNames = typesString.split(".")
     return ClassName(pkgName, simpleNames)
+  }
+
+  @AutoService(SymbolProcessorProvider::class)
+  public class Provider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        AutoServiceSymbolProcessor(environment)
   }
 }

--- a/processor/src/main/kotlin/dev/zacsweers/autoservice/ksp/AutoServiceSymbolProcessor.kt
+++ b/processor/src/main/kotlin/dev/zacsweers/autoservice/ksp/AutoServiceSymbolProcessor.kt
@@ -45,7 +45,7 @@ private class AutoServiceSymbolProcessor(environment: SymbolProcessorEnvironment
     SymbolProcessor {
 
   private companion object {
-    val AUTO_SERVICE_NAME = AutoService::class.qualifiedName!!
+    const val AUTO_SERVICE_NAME = "com.google.auto.service.AutoService"
   }
 
   private val codeGenerator = environment.codeGenerator
@@ -80,13 +80,17 @@ private class AutoServiceSymbolProcessor(environment: SymbolProcessorEnvironment
             .getClassDeclarationByName(resolver.getKSNameFromString(AUTO_SERVICE_NAME))
             ?.asType(emptyList())
             ?: run {
-              logger.error("@AutoService type not found on the classpath.")
+              val message = "@AutoService type not found on the classpath, skipping processing."
+              if (verbose) {
+                logger.warn(message)
+              } else {
+                logger.info(message)
+              }
               return emptyList()
             }
 
     resolver
         .getSymbolsWithAnnotation(AUTO_SERVICE_NAME)
-        .asSequence()
         .filterIsInstance<KSClassDeclaration>()
         .forEach { providerImplementer ->
           val annotation =

--- a/processor/src/test/kotlin/dev/zacsweers/autoservice/ksp/AutoServiceSymbolProcessorTest.kt
+++ b/processor/src/test/kotlin/dev/zacsweers/autoservice/ksp/AutoServiceSymbolProcessorTest.kt
@@ -61,7 +61,7 @@ class AutoServiceSymbolProcessorTest(private val incremental: Boolean) {
         KotlinCompilation().apply {
           sources = listOf(source)
           inheritClassPath = true
-          symbolProcessorProviders = listOf(AutoServiceSymbolProcessorProvider())
+          symbolProcessorProviders = listOf(AutoServiceSymbolProcessor.Provider())
           kspIncremental = incremental
         }
     val result = compilation.compile()
@@ -93,7 +93,7 @@ class AutoServiceSymbolProcessorTest(private val incremental: Boolean) {
         KotlinCompilation().apply {
           sources = listOf(source)
           inheritClassPath = true
-          symbolProcessorProviders = listOf(AutoServiceSymbolProcessorProvider())
+          symbolProcessorProviders = listOf(AutoServiceSymbolProcessor.Provider())
           kspIncremental = incremental
         }
     val result = compilation.compile()


### PR DESCRIPTION
Resolves #30. This makes it `info` by default, or `warn` if verbose mode is enabled.

Removed a couple direct refs. Didn't bother with a test for this as I don't want to jump through the hoops to try to remove it from the inherited KCT classpath.